### PR TITLE
chore: update docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
----
-
 services:
   meilisearch:
     image: "getmeili/meilisearch:v1.7"
     environment:
-      MEILI_MASTER_KEY: "Moin"  # Change this to a secure value
+      MEILI_MASTER_KEY: "Moin" # Change this to a secure value
     volumes:
       - "meilisearch-data:/meili_data"
 
@@ -16,7 +14,7 @@ services:
       - "sqlite-data:/app/database/sqlite"
     environment:
       MEILI_HOST: "http://meilisearch:7700"
-      MEILI_KEY: "Moin"   # Change this to a secure value
+      MEILI_KEY: "Moin" # Change this to a secure value
     depends_on:
       - "meilisearch"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+---
 
 services:
   meilisearch:
@@ -11,7 +11,7 @@ services:
   web:
     build: .
     ports:
-      - "8000:8000"
+      - "80:8000"
     volumes:
       - "sqlite-data:/app/database/sqlite"
     environment:


### PR DESCRIPTION
Using the Docker Compose Version is deprecated and for HTTP Services it should be used Port 80