### PR TITLE
chore(compose): specify image source of melisearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   meilisearch:
-    image: "getmeili/meilisearch:v1.7"
+    image: "docker.io/getmeili/meilisearch:v1.7"
     environment:
       MEILI_MASTER_KEY: "Moin" # Change this to a secure value
     volumes:


### PR DESCRIPTION
Specify the source of Melisearch since it may not be default on other engines like podman or kubernetes to use docker.io by default