### PR TITLE
fix(docker): tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM python:3.11-alpine
 
 # Add Tini
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
+RUN apk add --no-cache tini
+# Tini is now available at /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--"]
 
 # Run your program under Tini
 CMD ["./docker-entrypoint.sh"]


### PR DESCRIPTION
Fixing importing mistakt for tini dropin replacement.

Alpine has a different install procedure that i forgot in previous PR