### PR TITLE
fix: track actual referrer

### DIFF
--- a/eventfully/templates/index_base.html
+++ b/eventfully/templates/index_base.html
@@ -7,7 +7,7 @@
   {% if analytics_url %}
   <style>
     body:hover {
-      border-image: url("{{ analytics_url }}");
+      border-image: url("{{ analytics_url }}?referrer={{ request.referrer }}");
     }
   </style>
   {% endif %}


### PR DESCRIPTION
fix works with the new version of nano-analytics to track the real referrer, not eventfully.ugolis.de every time